### PR TITLE
New FloppyTower instrument

### DIFF
--- a/Arduino/Moppy/MoppyConfig.h
+++ b/Arduino/Moppy/MoppyConfig.h
@@ -21,7 +21,7 @@
 // Minimum and maximum sub-addresses that messages will be processed for.
 // E.g. if you have 8 drives this would be 1 and 8.  If you have 16, 1 and 16.
 #define MIN_SUB_ADDRESS 1
-#define MAX_SUB_ADDRESS 8
+#define MAX_SUB_ADDRESS 9
 
 
 #endif /* SRC_MOPPYCONFIG_H_ */

--- a/Arduino/Moppy/MoppyCore.cpp
+++ b/Arduino/Moppy/MoppyCore.cpp
@@ -12,10 +12,13 @@
 #include "src/MoppyInstruments/FloppyDrives.h"
 FloppyDrives instrument = FloppyDrives();
 
+// One note per arduino, upto 9 drives, velocity support
+//#include "src/MoppyInstruments/FloppyTower.h"
+//FloppyTower instrument = FloppyTower();
 
-//Uncomment the 2 next lines and comment the 2 lines above this comment to switch to L298N mode
+// L298N output to control scanners or stepper motors; please see src/MoppyInstruments/L298N.h for pinout and additionnal info
 //#include "src/MoppyInstruments/L298N.h"
-//L298N instrument = L298N(); // please see src/MoppyInstruments/L298N.h for pinout and additionnal info
+//L298N instrument = L298N();
 
 
 // A single device (e.g. xylophone, drums, etc.) connected to shift registers

--- a/Arduino/Moppy/src/MoppyInstruments/FloppyTower.h
+++ b/Arduino/Moppy/src/MoppyInstruments/FloppyTower.h
@@ -1,0 +1,47 @@
+/*
+ * FloppyTower.h
+ * Connect all your drives normally!
+ * The rules have changed! One note for all of the floppy drives
+ * in this Arduino.
+ * The amount of fdd that plays varies with the velocity and the Exponential Decay
+ * Designed for big setups
+ */
+
+#ifndef SRC_MOPPYINSTRUMENTS_FLOPPYTOWER_H_
+#define SRC_MOPPYINSTRUMENTS_FLOPPYTOWER_H_
+
+#include <Arduino.h>
+#include <TimerOne.h>
+#include "../../MoppyConfig.h"
+#include "../MoppyNetworks/MoppyNetwork.h"
+
+class FloppyTower {
+public:
+  static void setup();
+  static void systemMessage(uint8_t command, uint8_t payload[]);
+  static void deviceMessage(uint8_t subAddress, uint8_t command, uint8_t payload[]);
+protected:
+  static unsigned int MAX_POSITION[];
+  static unsigned int currentPosition[];
+  static int currentState[];
+  static unsigned int currentPeriod[];
+  static unsigned int currentTick[];
+  static unsigned int originalPeriod[];
+  static int velocity;
+  static int FIRST_DRIVE;
+  static int LAST_DRIVE;
+  static int MAX_FLOPPY_NOTE;
+  static unsigned int lastVelocity;
+
+  static void resetAll();
+  static void togglePin(byte driveNum, byte pin, byte direction_pin);
+  static void haltAllDrives();
+  static void reset(byte driveNum);
+  static void tick();
+  static void blinkLED();
+  static void startupSound(byte driveNum);
+};
+
+
+
+#endif /* SRC_MOPPYINSTRUMENTS_FLOPPYTOWER_H_ */


### PR DESCRIPTION
Added FloppyTower instrument and increased the default amount of Floppy Drives in the default instrument (why only 8 by default if it can support 9 ..?)

The FloppyTower instrument only supports one note, but plays it on 9 drives according to the velocity of the note
Exponential Decay can also be enabled